### PR TITLE
Remove public marking on functions for internal use only

### DIFF
--- a/memory-rosette.rkt
+++ b/memory-rosette.rkt
@@ -30,10 +30,7 @@
                 ;; don't initialize ref.
                 ;; Otherwise, initailize ref with memory object output from specification program.
                 [ref #f])
-    (public load store create-concrete clone
-            ;; internal use only
-            lookup-init lookup-update 
-            )
+    (public load store create-concrete clone)
 
     (define (cal-size l)
       (define ans 0)


### PR DESCRIPTION
If functions are for uniquely internal use, why mark them as public?