### PR TITLE
Enforce methods in memory-*.rkt to be public only for objs of same class

### DIFF
--- a/memory-racket.rkt
+++ b/memory-racket.rkt
@@ -3,6 +3,10 @@
 (require "special.rkt" "ops-racket.rkt")
 (provide memory-racket%)
 
+
+;; Mask method which should only be public for object of memory-racket%
+(define-local-public-member lookup-init)
+
 (define memory-racket%
   (class* special% (equal<%> printable<%>)
     (super-new)
@@ -17,11 +21,8 @@
             ;; for backward interpret
             del lookup-update
             get-update-addr-val get-update-addr-with-val get-addr-with-val get-available-addr
-            get-live-mask
-            ;; internal use only
-            lookup-init
-            )
-
+            get-live-mask)
+    
     (define/public (custom-print port depth)
       (print `(memory% init: ,init update: ,update) port depth))
 
@@ -94,7 +95,7 @@
       (and (hash-has-key? storage addr)
            (hash-ref storage addr)))
     
-    (define (lookup-init addr) (lookup init addr))
+    (define/public (lookup-init addr) (lookup init addr))
     (define (lookup-update addr) (lookup update addr))
 
     (define (modify storage addr val)

--- a/memory-rosette.rkt
+++ b/memory-rosette.rkt
@@ -15,6 +15,11 @@
   (pretty-display (format "Finalize memory size ~a" memory-size))
   )
 
+
+;; Mask method which should only be public for object of memory-racket%
+(define-local-member-name lookup-init)
+(define-local-member-name lookup-update)
+
 (define memory-rosette%
   (class* special% (equal<%> printable<%>)
     (super-new)
@@ -30,11 +35,8 @@
                 ;; don't initialize ref.
                 ;; Otherwise, initialize ref with memory object output from specification program.
                 [ref #f])
-    (public load store create-concrete clone
-            ;; internal use only
-            lookup-init lookup-update 
-            )
-
+    (public load store create-concrete clone)
+    
     (define (cal-size l)
       (define ans 0)
       (for ([x l])
@@ -99,8 +101,8 @@
       (loop 0))
 
     
-    (define (lookup-init addr) (lookup init addr))
-    (define (lookup-update addr) (lookup update addr))
+    (define/public (lookup-init addr) (lookup init addr))
+    (define/public (lookup-update addr) (lookup update addr))
 
     (define (modify storage addr val)
       (define (loop index)


### PR DESCRIPTION
These are lookup-init for memory-racket and lookup-init and
lookup-update for memory-rosette.